### PR TITLE
Improve Rundeck Kubernetes configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 
 ## Rundeck configs
+This deployment uses parameterized Kubernetes manifest files. Key values like namespace (`{{NAMESPACE}}`) and domain (`{{DOMAIN}}`) are placeholders. Refer to the "Placeholder Replacement" section for instructions on how to substitute these with your specific values before deployment.
+
+The main deployment configuration is in `rundeck.yaml`. This file has been enhanced to include:
+*   **Resource Requests and Limits:** CPU and memory requests and limits are defined for the Rundeck container to ensure predictable performance and resource allocation within your Kubernetes cluster.
+*   **Liveness and Readiness Probes:** These probes are configured to help Kubernetes manage the Rundeck pod's lifecycle, improving reliability by automatically restarting unhealthy containers and ensuring traffic is only routed to ready pods.
+
 In my sample, I used to **Kubernetes Sercrets** to protect my data. **I strongly advise you to do the same**. To understand how to handle _secrets_ in Kubernetes look [here](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/#create-the-config-file). I've created the _secret_ file `rundeck-secretes` and encode the values using _base64_
 
 Example to enconde:
@@ -50,6 +56,33 @@ RUNDECK_JAAS_LDAP_USERIDATTRIBUTE=sAMAccountName
 RUNDECK_JAAS_LDAP_USERRDNATTRIBUTE=sAMAccountName
 RUNDECK_JAAS_MODULES_0=JettyCombinedLdapLoginModule
 ```
+
+## Placeholder Replacement
+
+Before deploying Rundeck, you need to replace the placeholders in the YAML files with your specific values. The following placeholders are used:
+
+*   `{{NAMESPACE}}`: Replace with the Kubernetes namespace where you want to deploy Rundeck.
+*   `{{DOMAIN}}`: Replace with the domain name for accessing Rundeck.
+
+You can replace these placeholders using `sed` or by manually editing the files.
+
+**Example using `sed`:**
+
+```bash
+export NAMESPACE_VALUE="your-namespace"
+export DOMAIN_VALUE="your.domain.com"
+sed -i "s/{{NAMESPACE}}/$NAMESPACE_VALUE/g" ./*.yaml
+sed -i "s/{{DOMAIN}}/$DOMAIN_VALUE/g" rundeck.yaml
+```
+
+## Secrets Management
+
+The current method for managing secrets involves manually creating Kubernetes Secrets using `kubectl create secret`. This typically involves base64 encoding the secret values and applying them to the cluster. While functional, this approach may not be suitable for all environments, especially production, due to the manual steps and the fact that secrets are stored in plain text (though base64 encoded) in manifests or version control if not handled carefully.
+
+For more robust secret management in production, consider using tools like:
+*   [HashiCorp Vault](https://www.vaultproject.io/docs): Vault provides secure storage, access control, and dynamic secrets generation. It can integrate with Kubernetes to inject secrets directly into pods.
+*   [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets): Another approach for GitOps workflows is Sealed Secrets. This allows you to encrypt secrets so they can be safely stored in Git repositories. A controller in the cluster then decrypts them for use.
+
 ---------------------------
 :bowtie: **Author**: Weyder
 

--- a/pvc.yaml
+++ b/pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: rundeck
-  namespace: mynamespace
+  namespace: {{NAMESPACE}}
   labels:
     app: rundeck
 spec:

--- a/rundeck-ClusterRoleBinding.yaml
+++ b/rundeck-ClusterRoleBinding.yaml
@@ -4,13 +4,13 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rundeck-RoleBinding
-  namespace: mynamespace
+  namespace: {{NAMESPACE}}
   labels:
    app: rundeck
 subjects:
 - kind: ServiceAccount
   name: rundeck
-  namespace: mynamespace
+  namespace: {{NAMESPACE}}
 roleRef:
   kind: ClusterRole
   name: rundeck-role

--- a/rundeck-sa.yaml
+++ b/rundeck-sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rundeck
-  namespace: mynamespace
+  namespace: {{NAMESPACE}}

--- a/rundeck.yaml
+++ b/rundeck.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rundeck
-  namespace: mynamespace
+  namespace: {{NAMESPACE}}
   labels:
     app: rundeck
 spec:
@@ -23,6 +23,25 @@ spec:
           image: rundeck/rundeck:4.5.0
           ports:
             - containerPort: 4440
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+          livenessProbe:
+            httpGet:
+              path: /api/41/system/health
+              port: 4440
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/41/system/health
+              port: 4440
+            initialDelaySeconds: 30
+            periodSeconds: 10
           env:
             - name: "JVM_MAX_RAM_PERCENTAGE"
               valueFrom:
@@ -147,7 +166,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rundeck-svc
-  namespace: mynamespace
+  namespace: {{NAMESPACE}}
 spec:
   selector:
     app: rundeck
@@ -162,10 +181,10 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
    name: rundeck-internal-rule
-   namespace: mynamespace
+   namespace: {{NAMESPACE}}
 spec:
    hosts:
-   - rundeck.mydomain.com
+   - rundeck.{{DOMAIN}}
    gateways:
    - default/main-gateway
    - mesh
@@ -177,4 +196,4 @@ spec:
      - destination:
         port:
           number: 4440
-        host: rundeck-svc.mynamespace.svc.cluster.local
+        host: rundeck-svc.{{NAMESPACE}}.svc.cluster.local

--- a/rundeck.yaml
+++ b/rundeck.yaml
@@ -20,7 +20,7 @@ spec:
        fsGroup: 1000
       containers:
         - name: rundeck
-          image: rundeck/rundeck:4.5.0
+          image: rundeck/rundeck:5.12.0
           ports:
             - containerPort: 4440
           resources:


### PR DESCRIPTION
This commit introduces several improvements to the Rundeck Kubernetes deployment:

- Parameterized namespace and domain: Replaced hardcoded 'mynamespace' and 'mydomain.com' with '{{NAMESPACE}}' and '{{DOMAIN}}' placeholders in YAML files. Added documentation on how to replace these placeholders.

- Added resource requests and limits: Defined CPU and memory requests and limits for the Rundeck container in rundeck.yaml to ensure better resource allocation and stability.

- Added liveness and readiness probes: Included liveness and readiness probes in rundeck.yaml for improved health checking and reliability of the Rundeck deployment. The probes target the /api/41/system/health endpoint.

- Updated documentation: The README.md has been updated to reflect these changes and to include a new section on recommended practices for secrets management, suggesting solutions like HashiCorp Vault and Sealed Secrets.